### PR TITLE
fix: Fix naming

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Mihail Catan Service Auto</title>
+    <title>Mihail Catan Auto Repair</title>
     <link rel="stylesheet" href="reset.css" />
     <link rel="stylesheet" href="style.css" />
     <link rel="icon" href="img/logo-black.png" type="image/png" />
@@ -17,7 +17,7 @@
       <div id="banner">
         <img
           src="img/logo-black.png"
-          alt="Logo Mihail Catan Service Auto"
+          alt="Logo Mihail Catan Auto Repair"
           id="logo-header"
         />
         <h1 id="slogan">Mașina Ta, Prioritatea Noastră</h1>
@@ -36,7 +36,7 @@
           <div id="left-column">
             <h2>
               Bine ați venit la <br />
-              Mihail Catan Service Auto
+              Mihail Catan Auto Repair
             </h2>
             <p>
               Oferim servicii auto de înaltă calitate, cu onestitate și
@@ -142,7 +142,7 @@
         <div id="about-container">
           <h2>De ce să ne alegi?</h2>
           <p>
-            La Mihail Catan Service Auto, ne mândrim cu angajamentul nostru față
+            La Mihail Catan Auto Repair, ne mândrim cu angajamentul nostru față
             de calitate, onestitate și satisfacția clienților. Iată de ce suntem
             alegerea potrivită pentru toate nevoile tale auto:
           </p>
@@ -280,11 +280,11 @@
     </main>
     <footer>
       <p id="footer-text">
-        &copy; 2026 Mihail Catan Service Auto. Toate drepturile rezervate.
+        &copy; 2026 Mihail Catan Auto Repair. Toate drepturile rezervate.
       </p>
       <img
         src="img/logo-white.png"
-        alt="Logo Mihail Catan Service Auto"
+        alt="Logo Mihail Catan Auto Repair"
         id="footer-logo"
       />
       <p id="contact-info">


### PR DESCRIPTION
This pull request updates the branding throughout the `index.html` file, changing all references from "Mihail Catan Service Auto" to "Mihail Catan Auto Repair." This ensures consistency in the business name across the website.

Branding updates:

* Changed the page title to "Mihail Catan Auto Repair" (`index.html`)
* Updated all visible text and alt attributes from "Mihail Catan Service Auto" to "Mihail Catan Auto Repair" in headings, paragraphs, and image descriptions (`index.html`) [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L20-R20) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L39-R39) [[3]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L145-R145) [[4]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L283-R287)