### PR TITLE
fix: Remove unnecessary line break

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
             <div class="services-item">
               <img src="img/oil.png" alt="Schimb ulei" class="services-image" />
               <p>
-                Menține motorul în stare optimă cu schimb rapid de ulei.<br />
+                Menține motorul în stare optimă cu schimb rapid de ulei.
                 Folosim uleiuri de calitate superioară pentru performanță și
                 durabilitate.</p>
               <a class="learn-more" href="#contact">Află mai mult</a>


### PR DESCRIPTION
This pull request makes a minor change to the `index.html` file, specifically in the services section. The change removes an unnecessary line break to improve the formatting of the oil change service description.